### PR TITLE
[DEV] 매거진/섹션/문단 삭제 확인 모달 및 토스트추가

### DIFF
--- a/Mine/src/components/common/ConfirmModal.tsx
+++ b/Mine/src/components/common/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 interface ConfirmModalProps {
     title: string
     description?: string
+    itemName?: string
     confirmText?: string
     cancelText?: string
     onConfirm: () => void
@@ -11,6 +12,7 @@ interface ConfirmModalProps {
 export default function ConfirmModal({
     title,
     description,
+    itemName,
     confirmText = '예',
     cancelText = '아니요',
     onConfirm,
@@ -18,16 +20,18 @@ export default function ConfirmModal({
     isLoading = false,
 }: ConfirmModalProps) {
     return (
-        <div className="fixed inset-0 bg-black/40 z-999 flex items-center justify-center">
+        <div className="fixed inset-0 bg-gray-600-op40 z-999 flex items-center justify-center">
             <div className="relative z-10 w-120 h-53 rounded-2xl bg-gray-600-op70 px-8 py-8 flex flex-col justify-between shadow-[0_4px_8px_rgba(0,0,0,0.12),0_16px_32px_rgba(0,0,0,0.20)]">
                 <div>
-                    <h2 className="mb-3 font-semibold24 text-white">{title}</h2>
-                    {description && (
+                    <h2 className="mb-3 font-semibold24 text-gray-100">{title}</h2>
+                    {(description || itemName) && (
                         <p
-                            className="font-regular20 text-white/70 whitespace-pre-line"
+                            className="font-regular20 text-gray-100-op70 whitespace-pre-line"
                             style={{ fontFeatureSettings: "'liga' off, 'clig' off" }}
                         >
-                            {description}
+                            {description && <span>{description} </span>}
+                            {itemName && <span className="font-semibold20 text-gray-100">{itemName}</span>}
+                            {itemName && <span>이(가) 삭제됩니다.</span>}
                         </p>
                     )}
                 </div>
@@ -36,13 +40,13 @@ export default function ConfirmModal({
                     <button
                         onClick={onConfirm}
                         disabled={isLoading}
-                        className="flex items-center justify-center w-25 h-12 rounded-lg border border-white/30 font-medium16 text-white hover:bg-gray-600-op70 disabled:opacity-50"
+                        className="flex items-center justify-center w-25 h-12 rounded-lg border border-gray-100-op30 font-medium16 text-gray-100 hover:bg-gray-600-op70 disabled:opacity-50"
                     >
                         {isLoading ? '생성 중...' : confirmText}
                     </button>
                     <button
                         onClick={onCancel}
-                        className="flex items-center justify-center w-25 h-12 rounded-lg border border-white/30 font-medium16 text-white hover:bg-gray-600-op70"
+                        className="flex items-center justify-center w-25 h-12 rounded-lg border border-gray-100-op30 font-medium16 text-gray-100 hover:bg-gray-600-op70"
                     >
                         {cancelText}
                     </button>

--- a/Mine/src/components/common/ConfirmModal.tsx
+++ b/Mine/src/components/common/ConfirmModal.tsx
@@ -30,8 +30,12 @@ export default function ConfirmModal({
                             style={{ fontFeatureSettings: "'liga' off, 'clig' off" }}
                         >
                             {description && <span>{description} </span>}
-                            {itemName && <span className="font-semibold20 text-gray-100">{itemName}</span>}
-                            {itemName && <span>이(가) 삭제됩니다.</span>}
+                            {itemName && (
+                                <>
+                                    <span className="font-semibold20 text-gray-100">{itemName}</span>
+                                    <span>이(가) 삭제됩니다.</span>
+                                </>
+                            )}
                         </p>
                     )}
                 </div>
@@ -42,7 +46,7 @@ export default function ConfirmModal({
                         disabled={isLoading}
                         className="flex items-center justify-center w-25 h-12 rounded-lg border border-gray-100-op30 font-medium16 text-gray-100 hover:bg-gray-600-op70 disabled:opacity-50"
                     >
-                        {isLoading ? '생성 중...' : confirmText}
+                        {isLoading ? '처리 중...' : confirmText}
                     </button>
                     <button
                         onClick={onCancel}

--- a/Mine/src/components/common/Toast.tsx
+++ b/Mine/src/components/common/Toast.tsx
@@ -6,7 +6,7 @@ interface ToastProps {
 
 export default function Toast({ message }: ToastProps) {
     return (
-        <div className="flex w-67.5 h-12 px-5 py-3 items-center gap-1 rounded-lg bg-gray-500 font-regular14 text-white shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
+        <div className="flex w-67.5 h-12 px-5 py-3 items-center gap-3 rounded-lg bg-gray-600-op70 font-regular14 text-gray-100 shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
             <Check className="w-4 h-4 shrink-0 **:fill-current **:stroke-current" />
             <span>{message}</span>
         </div>

--- a/Mine/src/components/hamburgerModal/ParagraphHamburgerModal.tsx
+++ b/Mine/src/components/hamburgerModal/ParagraphHamburgerModal.tsx
@@ -1,9 +1,11 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import Edit from '../../icon/edit.svg?react'
 import Delete from '../../icon/delete.svg?react'
 import { HamburgerSection } from './HamburgerSection'
 import useDeleteParagraph from '../../hooks/useDeleteParagraph'
 import useClickOutside from '../../hooks/useClickOutside'
+import ConfirmModal from '../common/ConfirmModal'
+import { createPortal } from 'react-dom'
 
 interface ParagraphHamburgerModalProps {
     top: number
@@ -11,15 +13,15 @@ interface ParagraphHamburgerModalProps {
     sectionId?: number
     magazineId?: number
     paragraphId?: number
-    children?: React.ReactNode
+    subtitle: string
     handleClose: () => void
-    // onEdit: (id?: number) => void
 }
 
 export default function ParagraphHamburgerModal({
     paragraphId,
     sectionId,
     magazineId,
+    subtitle,
     top,
     left,
     handleClose,
@@ -28,24 +30,46 @@ export default function ParagraphHamburgerModal({
     useClickOutside(modalRef, handleClose)
 
     const deleteParagraphMutation = useDeleteParagraph()
-    const onDeleteClick: React.MouseEventHandler<HTMLDivElement> = () => {
+    const [showConfirmModal, setShowConfirmModal] = useState(false)
+
+    const onDeleteClick = () => {
+        setShowConfirmModal(true)
+    }
+
+    const onConfirmDelete = () => {
         deleteParagraphMutation.mutate({
             magazineId: Number(magazineId),
             sectionId: Number(sectionId),
             paragraphId: Number(paragraphId),
         })
+        setShowConfirmModal(false)
         handleClose()
     }
 
     return (
-        <div
-            ref={modalRef}
-            key={sectionId}
-            className="absolute flex flex-col px-1 py-1 rounded-lg bg-gray-500-op70 shadow-[0 4px 4px 0 rgba(0, 0, 0, 0.25)] z-100"
-            style={{ top: `${top}px`, left: `${left}px` }}
-        >
-            <HamburgerSection title="이름 변경" icon={<Edit />} />
-            <HamburgerSection title="삭제" icon={<Delete />} onClick={onDeleteClick} />
-        </div>
+        <>
+            {!showConfirmModal && (
+                <div
+                    ref={modalRef}
+                    className="absolute flex flex-col px-1 py-1 rounded-lg bg-gray-500-op70 shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] z-100"
+                    style={{ top: `${top}px`, left: `${left}px` }}
+                >
+                    <HamburgerSection title="이름 변경" icon={<Edit />} />
+                    <HamburgerSection title="삭제" icon={<Delete />} onClick={onDeleteClick} />
+                </div>
+            )}
+
+            {showConfirmModal &&
+                createPortal(
+                    <ConfirmModal
+                        title="해당 문단을 삭제하시겠습니까?"
+                        description="문단"
+                        itemName={subtitle}
+                        onConfirm={onConfirmDelete}
+                        onCancel={() => setShowConfirmModal(false)}
+                    />,
+                    document.body
+                )}
+        </>
     )
 }

--- a/Mine/src/components/hamburgerModal/SectionHamburgerModal.tsx
+++ b/Mine/src/components/hamburgerModal/SectionHamburgerModal.tsx
@@ -6,18 +6,23 @@ import { HamburgerSection } from './HamburgerSection'
 import useDeleteSection from '../../hooks/useDeleteSection'
 import ShareModal from './ShareModal'
 import useClickOutside from '../../hooks/useClickOutside'
+import ConfirmModal from '../common/ConfirmModal'
+import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router-dom'
 
 interface SectionHamburgerModalProps {
     top: number
     left: number
     sectionId?: number
     magazineId?: number
+    heading: string
     handleClose: () => void
 }
 
 export default function SectionHamburgerModal({
     sectionId,
     magazineId,
+    heading,
     top,
     left,
     handleClose,
@@ -25,17 +30,28 @@ export default function SectionHamburgerModal({
     const modalRef = useRef<HTMLDivElement>(null)
     useClickOutside(modalRef, handleClose)
 
-    const deleteSectionMutation = useDeleteSection()
+    const navigate = useNavigate()
+    const deleteSectionMutation = useDeleteSection({
+        onSuccess: () => {
+            navigate(`/${magazineId}`)
+        }
+    })
     const [showShareModal, setShowShareModal] = useState(false)
+    const [showConfirmModal, setShowConfirmModal] = useState(false)
 
-    const onDeleteClick: React.MouseEventHandler<HTMLDivElement> = () => {
+    const onDeleteClick = () => {
+        setShowConfirmModal(true)
+    }
+
+    const onConfirmDelete = () => {
         deleteSectionMutation.mutate({ magazineId: Number(magazineId), sectionId: Number(sectionId) })
+        setShowConfirmModal(false)
         handleClose()
     }
 
     return (
         <>
-            {!showShareModal && (
+            {!showShareModal && !showConfirmModal && (
                 <div
                     ref={modalRef}
                     className="absolute flex flex-col px-1 py-1 rounded-lg bg-gray-500-op70 shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] z-100"
@@ -48,6 +64,18 @@ export default function SectionHamburgerModal({
             )}
 
             {showShareModal && <ShareModal onClose={handleClose} />}
+
+            {showConfirmModal &&
+                createPortal(
+                    <ConfirmModal
+                        title="해당 섹션을 삭제하시겠습니까?"
+                        description="섹션"
+                        itemName={heading}
+                        onConfirm={onConfirmDelete}
+                        onCancel={() => setShowConfirmModal(false)}
+                    />,
+                    document.body
+                )}
         </>
     )
 }

--- a/Mine/src/components/hamburgerModal/SidebarHamburgerModal.tsx
+++ b/Mine/src/components/hamburgerModal/SidebarHamburgerModal.tsx
@@ -2,30 +2,46 @@ import { useState, useRef } from 'react'
 import Share from '../../icon/share.svg?react'
 import Edit from '../../icon/edit.svg?react'
 import Delete from '../../icon/delete.svg?react'
-import useDeleteMagazine from '../../hooks/useDeleteMagazine'
 import { HamburgerSection } from './HamburgerSection'
+import useDeleteMagazine from '../../hooks/useDeleteMagazine'
 import useClickOutside from '../../hooks/useClickOutside'
 import ShareModal from './ShareModal'
+import ConfirmModal from '../common/ConfirmModal'
+import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router-dom'
 
 interface SidebarHamburgerModalProps {
     top: number
     left: number
     id: number
+    title: string
     handleClose: () => void
     onEdit: (id: number) => void
 }
 
-export default function SidebarHamburgerModal({ id, top, left, handleClose, onEdit }: SidebarHamburgerModalProps) {
+export default function SidebarHamburgerModal({ id, title, top, left, handleClose, onEdit }: SidebarHamburgerModalProps) {
     const modalRef = useRef<HTMLDivElement>(null)
     useClickOutside(modalRef, handleClose)
 
-    const deleteMutation = useDeleteMagazine()
+    const navigate = useNavigate()
+    const deleteMutation = useDeleteMagazine({
+        onSuccess: () => {
+            navigate('/')
+        }
+    })
     const [showShareModal, setShowShareModal] = useState(false)
+    const [showConfirmModal, setShowConfirmModal] = useState(false)
 
-    const onDeleteClick: React.MouseEventHandler<HTMLDivElement> = () => {
-        deleteMutation.mutate({ id: id })
+    const onDeleteClick = () => {
+        setShowConfirmModal(true)
+    }
+
+    const onConfirmDelete = () => {
+        deleteMutation.mutate({ id })
+        setShowConfirmModal(false)
         handleClose()
     }
+
     const onEditClick: React.MouseEventHandler<HTMLDivElement> = () => {
         onEdit(id)
         handleClose()
@@ -33,10 +49,9 @@ export default function SidebarHamburgerModal({ id, top, left, handleClose, onEd
 
     return (
         <>
-            {!showShareModal && (
+            {!showShareModal && !showConfirmModal && (
                 <div
                     ref={modalRef}
-                    key={id}
                     className="absolute flex flex-col px-1 py-2 rounded-lg bg-gray-500-op70 shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] z-100"
                     style={{ top: `${top}px`, left: `${left}px` }}
                 >
@@ -47,6 +62,18 @@ export default function SidebarHamburgerModal({ id, top, left, handleClose, onEd
             )}
 
             {showShareModal && <ShareModal onClose={handleClose} />}
+
+            {showConfirmModal &&
+                createPortal(
+                    <ConfirmModal
+                        title="해당 매거진을 삭제하시겠습니까?"
+                        description="매거진"
+                        itemName={title}
+                        onConfirm={onConfirmDelete}
+                        onCancel={() => setShowConfirmModal(false)}
+                    />,
+                    document.body
+                )}
         </>
     )
 }

--- a/Mine/src/hooks/useDeleteMagazine.ts
+++ b/Mine/src/hooks/useDeleteMagazine.ts
@@ -1,17 +1,48 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteMagazine } from '../api/magazine'
-import type { RequestDeleteMagazine } from '../types/magazine'
+import type { RequestDeleteMagazine, ResponseMyMagazine } from '../types/magazine'
+import useToastStore from '../stores/toast'
 
-export default function useDeleteMagazine() {
+interface UseDeleteMagazineOptions {
+    onSuccess?: () => void
+}
+
+export default function useDeleteMagazine(options?: UseDeleteMagazineOptions) {
     const queryClient = useQueryClient()
+    const { showToast } = useToastStore()
+
     return useMutation({
         mutationFn: (params: RequestDeleteMagazine) => deleteMagazine(params),
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['mymagazines'] })
+        onMutate: async ({ id }) => {
+            await queryClient.cancelQueries({ queryKey: ['mymagazines'] })
+            const previousData = queryClient.getQueriesData<ResponseMyMagazine>({ queryKey: ['mymagazines'] })
+            queryClient.setQueriesData<ResponseMyMagazine>(
+                { queryKey: ['mymagazines'] },
+                (old) => {
+                    if (!old) return old
+                    return {
+                        ...old,
+                        content: old.content.filter((m) => m.magazineId !== id),
+                    }
+                }
+            )
+            return { previousData }
         },
-        onError: (error) => {
-            console.log('삭제 실패', error)
+        onSuccess: () => {
+            showToast('매거진이 삭제되었습니다.')
+            options?.onSuccess?.()
+        },
+        onError: (_, __, context) => {
+            if (context?.previousData) {
+                context.previousData.forEach(([queryKey, data]) => {
+                    queryClient.setQueryData(queryKey, data)
+                })
+            }
             alert('매거진 삭제에 실패했습니다. 잠시 후에 다시 시도해 주세요')
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries({ queryKey: ['mymagazines'] })
+            queryClient.invalidateQueries({ queryKey: ['recentsections'] })
         },
     })
 }

--- a/Mine/src/hooks/useDeleteParagraph.ts
+++ b/Mine/src/hooks/useDeleteParagraph.ts
@@ -1,17 +1,38 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteParagraph } from '../api/magazine'
-import type { DeleteParagraphDto } from '../types/magazine'
+import type { DeleteParagraphDto, ResponseGetSectionDetail } from '../types/magazine'
+import useToastStore from '../stores/toast'
 
 export default function useDeleteParagraph() {
     const queryClient = useQueryClient()
+    const { showToast } = useToastStore()
+
     return useMutation({
         mutationFn: (params: DeleteParagraphDto) => deleteParagraph(params),
-        onSuccess: (_, variables) => {
-            queryClient.invalidateQueries({ queryKey: ['mymagazines', variables.paragraphId] })
+        onMutate: async ({ magazineId, sectionId, paragraphId }) => {
+            await queryClient.cancelQueries({ queryKey: ['section', magazineId, sectionId] })
+            const previousData = queryClient.getQueryData<ResponseGetSectionDetail>(['section', magazineId, sectionId])
+            queryClient.setQueryData<ResponseGetSectionDetail>(['section', magazineId, sectionId], (old) => {
+                if (!old) return old
+                return {
+                    ...old,
+                    paragraphs: old.paragraphs.filter((p) => p.paragraphId !== paragraphId),
+                }
+            })
+            return { previousData, magazineId, sectionId }
         },
-        onError: (error) => {
-            console.log('삭제 실패', error)
+        onSuccess: () => {
+            showToast('문단이 삭제되었습니다.')
+        },
+        onError: (_, __, context) => {
+            if (context?.previousData) {
+                queryClient.setQueryData(['section', context.magazineId, context.sectionId], context.previousData)
+            }
             alert('문단 삭제에 실패했습니다. 잠시 후에 다시 시도해 주세요')
+        },
+        onSettled: (_, __, variables) => {
+            queryClient.invalidateQueries({ queryKey: ['section', variables.magazineId, variables.sectionId] })
+            queryClient.invalidateQueries({ queryKey: ['recentsections'] })
         },
     })
 }

--- a/Mine/src/hooks/useDeleteSection.tsx
+++ b/Mine/src/hooks/useDeleteSection.tsx
@@ -1,17 +1,43 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteSection } from '../api/magazine'
-import type { DeleteSectionDto } from '../types/magazine'
+import type { DeleteSectionDto, ResponseMagazineDetail } from '../types/magazine'
+import useToastStore from '../stores/toast'
 
-export default function useDeleteSection() {
+interface UseDeleteSectionOptions {
+    onSuccess?: () => void
+}
+
+export default function useDeleteSection(options?: UseDeleteSectionOptions) {
     const queryClient = useQueryClient()
+    const { showToast } = useToastStore()
+
     return useMutation({
         mutationFn: (params: DeleteSectionDto) => deleteSection(params),
-        onSuccess: (_, variables) => {
-            queryClient.invalidateQueries({ queryKey: ['magazine', variables.magazineId] })
+        onMutate: async ({ magazineId, sectionId }) => {
+            await queryClient.cancelQueries({ queryKey: ['magazine', magazineId] })
+            const previousData = queryClient.getQueryData<ResponseMagazineDetail>(['magazine', magazineId])
+            queryClient.setQueryData<ResponseMagazineDetail>(['magazine', magazineId], (old) => {
+                if (!old) return old
+                return {
+                    ...old,
+                    sections: old.sections.filter((s) => s.sectionId !== sectionId),
+                }
+            })
+            return { previousData, magazineId }
         },
-        onError: (error) => {
-            console.log('삭제 실패', error)
+        onSuccess: () => {
+            showToast('섹션이 삭제되었습니다.')
+            options?.onSuccess?.()
+        },
+        onError: (_, __, context) => {
+            if (context?.previousData) {
+                queryClient.setQueryData(['magazine', context.magazineId], context.previousData)
+            }
             alert('섹션 삭제에 실패했습니다. 잠시 후에 다시 시도해 주세요')
+        },
+        onSettled: (_, __, variables) => {
+            queryClient.invalidateQueries({ queryKey: ['magazine', variables.magazineId] })
+            queryClient.invalidateQueries({ queryKey: ['recentsections'] })
         },
     })
 }

--- a/Mine/src/hooks/usePostMagazine.ts
+++ b/Mine/src/hooks/usePostMagazine.ts
@@ -1,16 +1,19 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { PostMagazineDto } from '../types/magazine'
 import { postMagazine } from '../api/magazine'
+import { useNavigate } from 'react-router-dom'
 
 export default function usePostMagazine() {
     const queryClient = useQueryClient()
+    const navigate = useNavigate()
+
     return useMutation({
         mutationFn: ({ topic, user_mood }: PostMagazineDto) => postMagazine({ topic, user_mood }),
-        onSuccess: () => {
+        onSuccess: (data) => {
             queryClient.invalidateQueries({ queryKey: ['mymagazines'] })
+            navigate(`/${data}`)
         },
-        onError: (error) => {
-            console.log('매거진 생성 실패:', error)
+        onError: () => {
             alert('매거진 생성에 실패했습니다.')
         },
     })

--- a/Mine/src/layout/Layout.tsx
+++ b/Mine/src/layout/Layout.tsx
@@ -20,7 +20,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             {isLoggedIn && <Sidebar />}
             <main className="h-full w-full overflow-y-auto duration-300">{children}</main>
             {message && (
-                <div className="fixed z-[9999] bottom-10 left-1/2 -translate-x-1/2">
+                <div className="fixed z-9999 bottom-10 left-1/2 -translate-x-1/2">
                     <Toast message={message} />
                 </div>
             )}

--- a/Mine/src/layout/Layout.tsx
+++ b/Mine/src/layout/Layout.tsx
@@ -1,14 +1,29 @@
 import type React from 'react'
 import Sidebar from './Sidebar'
 import { useAuthStore } from '../stores/auth'
+import useToastStore from '../stores/toast'
+import Toast from '../components/common/Toast'
+import { useEffect } from 'react'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const { isLoggedIn } = useAuthStore()
+    const { message, hideToast } = useToastStore()
+
+    useEffect(() => {
+        if (!message) return
+        const timer = setTimeout(() => hideToast(), 3000)
+        return () => clearTimeout(timer)
+    }, [message, hideToast])
+
     return (
         <div className="relative h-screen w-full overflow-hidden">
             {isLoggedIn && <Sidebar />}
-
             <main className="h-full w-full overflow-y-auto duration-300">{children}</main>
+            {message && (
+                <div className="fixed z-[9999]" style={{ top: '613px', left: '585px' }}>
+                    <Toast message={message} />
+                </div>
+            )}
         </div>
     )
 }

--- a/Mine/src/layout/Layout.tsx
+++ b/Mine/src/layout/Layout.tsx
@@ -20,7 +20,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             {isLoggedIn && <Sidebar />}
             <main className="h-full w-full overflow-y-auto duration-300">{children}</main>
             {message && (
-                <div className="fixed z-[9999]" style={{ top: '613px', left: '585px' }}>
+                <div className="fixed z-[9999] bottom-10 left-1/2 -translate-x-1/2">
                     <Toast message={message} />
                 </div>
             )}

--- a/Mine/src/layout/sidebar/SidebarMagazine.tsx
+++ b/Mine/src/layout/sidebar/SidebarMagazine.tsx
@@ -89,7 +89,6 @@ export default function SidebarMagazine({ title, id, onclick }: SidebarMagazineP
     return (
         <div className="w-full flex flex-col">
             <div
-                key={id}
                 className={`w-full flex justify-between group hover:bg-gray-600-op70 hover:text-gray-100 py-2 items-center pl-5 pr-4 text-gray-100-op70 font-medium14 select-none ${
                     isEditing ? 'bg-gray-600-op70' : ''
                 }`}
@@ -120,6 +119,7 @@ export default function SidebarMagazine({ title, id, onclick }: SidebarMagazineP
                     <SidebarHamburgerModal
                         handleClose={closeHamburger}
                         id={id}
+                        title={title}
                         top={modalPos.top}
                         left={modalPos.left}
                         onEdit={() => beginEdit()}

--- a/Mine/src/pages/magazine/MagazinePage.tsx
+++ b/Mine/src/pages/magazine/MagazinePage.tsx
@@ -74,6 +74,7 @@ export default function MagazinePage() {
                     {data.user && (
                         <div className="mt-9 pr-7 pl-10.5">
                             <MagazineInfo
+                                title={data.title}
                                 nickname={data.user.nickname}
                                 profileImage={data.user.profileImageUrl}
                                 magazineId={data.magazineId}

--- a/Mine/src/pages/magazine/components/MagazineInfo.tsx
+++ b/Mine/src/pages/magazine/components/MagazineInfo.tsx
@@ -63,6 +63,8 @@ export default function MagazineInfo({ nickname, profileImage, sectionId, mode, 
         }
     }
 
+    const currentHeading = magazinedata?.sections?.find((s) => s.sectionId === sectionId)?.heading ?? ''
+
     return (
         <div className="flex w-full justify-between items-center self-stretch">
             <div className="flex items-center gap-2 basis-100">
@@ -95,6 +97,7 @@ export default function MagazineInfo({ nickname, profileImage, sectionId, mode, 
                                 handleClose={closeHamburger}
                                 magazineId={magazinedata?.magazineId}
                                 sectionId={sectionId}
+                                heading={currentHeading}
                                 top={10}
                                 left={10}
                             />
@@ -104,6 +107,7 @@ export default function MagazineInfo({ nickname, profileImage, sectionId, mode, 
                         <SidebarHamburgerModal
                             handleClose={closeHamburger}
                             id={magazinedata.magazineId}
+                            title={magazinedata.title ?? ''}
                             top={10}
                             left={10}
                             onEdit={() => {

--- a/Mine/src/pages/magazine/components/MagazineInfo.tsx
+++ b/Mine/src/pages/magazine/components/MagazineInfo.tsx
@@ -8,6 +8,7 @@ import { useMagazine } from '../MagazineProvider'
 import useUpdateMagazineTitle from '../../../hooks/useUpdateMagazineTitle'
 
 interface MagazineInfoProps {
+    title?: string
     nickname?: string
     profileImage?: string
     magazineId?: number
@@ -16,7 +17,7 @@ interface MagazineInfoProps {
     onClick?: (magazineId: number) => void
 }
 
-export default function MagazineInfo({ nickname, profileImage, sectionId, mode, onClick }: MagazineInfoProps) {
+export default function MagazineInfo({ title, nickname, profileImage, sectionId, mode, onClick }: MagazineInfoProps) {
     const magazinedata = useMagazine()
     const [isHamburgerOpen, setIsHamburgerOpen] = useState(false)
     const [isEditing, setIsEditing] = useState(false)
@@ -63,7 +64,7 @@ export default function MagazineInfo({ nickname, profileImage, sectionId, mode, 
         }
     }
 
-    const currentHeading = magazinedata?.sections?.find((s) => s.sectionId === sectionId)?.heading ?? ''
+    const currentSectionHeading = magazinedata?.sections?.find((s) => s.sectionId === sectionId)?.heading ?? ''
 
     return (
         <div className="flex w-full justify-between items-center self-stretch">
@@ -73,7 +74,7 @@ export default function MagazineInfo({ nickname, profileImage, sectionId, mode, 
                         className={`cursor-pointer ${mode === 'section' ? 'font-regular16 font-notoserif text-gray-600' : 'font-semibold20 font-pretendard text-gray-100'}`}
                         onClick={() => magazinedata?.magazineId && onClick?.(magazinedata.magazineId)}
                     >
-                        {magazinedata?.title}
+                        {title}
                     </div>
                 ) : (
                     <input
@@ -97,7 +98,7 @@ export default function MagazineInfo({ nickname, profileImage, sectionId, mode, 
                                 handleClose={closeHamburger}
                                 magazineId={magazinedata?.magazineId}
                                 sectionId={sectionId}
-                                heading={currentHeading}
+                                heading={currentSectionHeading}
                                 top={10}
                                 left={10}
                             />

--- a/Mine/src/pages/magazine/components/ParagraphPart.tsx
+++ b/Mine/src/pages/magazine/components/ParagraphPart.tsx
@@ -31,9 +31,9 @@ export default function ParagraphPart({
 
     return (
         <section className="group flex w-full items-center gap-10" dir={sectionDir}>
-            {imageUrl && <img src={imageUrl} className="object-scale-down max-h-70 max-w-[45%] shrink-0 "></img>}
+            {imageUrl && <img src={imageUrl} className="object-scale-down max-h-70 max-w-[45%] shrink-0" />}
             <div className="flex flex-col ltr:ml-2.5 rtl:mr-2.5 h-full items-start gap-6 flex-1">
-                <div className="flex w-full justify-between items-center " dir={titleDir}>
+                <div className="flex w-full justify-between items-center" dir={titleDir}>
                     <div className="font-medium36 font-notoserif text-gray-600">{smallTitle}</div>
                     <div className="relative flex items-center" dir="ltr">
                         <Hamburger
@@ -46,14 +46,14 @@ export default function ParagraphPart({
                                 sectionId={sectionId}
                                 magazineId={magazinedata?.magazineId}
                                 paragraphId={paragrahId}
+                                subtitle={smallTitle ?? ''}
                                 top={10}
                                 left={10}
-                                // onEdit={}
                             />
                         )}
                     </div>
                 </div>
-                <div className="w-full font-regular16 text-black-textMain break-all " dir="ltr">
+                <div className="w-full font-regular16 text-black-textMain break-all" dir="ltr">
                     <ReactMarkDown>{content}</ReactMarkDown>
                 </div>
             </div>

--- a/Mine/src/pages/magazine/components/SectionContent.tsx
+++ b/Mine/src/pages/magazine/components/SectionContent.tsx
@@ -71,6 +71,7 @@ export default function SectionContent({ sectionId, magazineId }: SectionContent
                     <SectionIndexList sectionId={Number(sectionId)} />
                     <div className="flex flex-col w-245 items-center gap-14 mt-9 mb-22 z-10">
                         <MagazineInfo
+                            title={data?.heading}
                             nickname={user?.nickname}
                             profileImage={user?.profileImageUrl}
                             sectionId={Number(sectionId)}

--- a/Mine/src/pages/main/MainPage.tsx
+++ b/Mine/src/pages/main/MainPage.tsx
@@ -17,7 +17,8 @@ export default function MainPage() {
 
     const handleSend = () => {
         if (!topic.trim()) return
-        postMagazineMutation.mutate({ topic: topic, user_mood: userMood })
+        if (isPending) return
+        postMagazineMutation.mutate({ topic, user_mood: userMood })
     }
 
     return (

--- a/Mine/src/stores/toast.ts
+++ b/Mine/src/stores/toast.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+interface ToastState {
+    message: string | null
+    showToast: (message: string) => void
+    hideToast: () => void
+}
+
+const useToastStore = create<ToastState>((set) => ({
+    message: null,
+    showToast: (message) => set({ message }),
+    hideToast: () => set({ message: null }),
+}))
+
+export default useToastStore


### PR DESCRIPTION
## 🔗 관련 이슈
closed #96 

## ✨ 요약
- 매거진/섹션/문단 삭제 확인 모달 및 토스트 추가했습니다.
- 문단 삭제시 기존 레이아웃을 유지하며 화면 변경
- 섹션 삭제시 매거진 페이지로 이동
- 매거진 삭제시 매거진 생성 페이지로 이동
추가적으로
- 섹션이나 매거진 삭제시 관련 최근 열람한 섹션도 함께 삭제되도록 구현
- 매거진 생성 시 새로 생긴 매거진 페이지 화면으로 바로 연결되도록 구현



