### PR TITLE
[DEV] 남이 만든 매거진 페이지에서 LLM, 햄버거 삭제

### DIFF
--- a/Mine/src/api/magazine.ts
+++ b/Mine/src/api/magazine.ts
@@ -86,7 +86,7 @@ export const deleteParagraph = async ({ magazineId, sectionId, paragraphId }: De
     return res.data
 }
 
-export const getMagazineFeed = async ({ cursorId, limit = 10 }: FeedDto): Promise<ResponseFeed> => {
+export const getMagazineFeed = async ({ cursorId, limit = 15 }: FeedDto): Promise<ResponseFeed> => {
     const res = await axiosInstance.get(`/api/magazines/feed`, {
         params: { cursorId, limit },
     })

--- a/Mine/src/components/LLMInputLayout.tsx
+++ b/Mine/src/components/LLMInputLayout.tsx
@@ -11,7 +11,7 @@ export default function LLMInputLayout() {
     const { isLoggedIn } = useAuthStore()
     const { user } = useUserStore()
     const location = useLocation()
-    const hiddenPath = ['/login', '/signup', '/landing', '/']
+    const hiddenPath = ['/login', '/signup', '/landing', '/explore', '/saved']
     const isHiddenPath = hiddenPath.includes(location.pathname)
 
     const postAddSectionMutation = usePostAddSection()
@@ -22,18 +22,18 @@ export default function LLMInputLayout() {
     const magazineMatch = matchPath('/:magazineId', location.pathname)
 
     //magazineId 추출
-    const currentMagazineId = magazineMatch?.params.magazineId
+    const currentMagazineId = sectionMatch?.params.magazineId || magazineMatch?.params.magazineId
     const isNumericMagazineId = currentMagazineId && !isNaN(Number(currentMagazineId))
 
     const { data: magazineDetail } = useGetMagazineDetail(Number(currentMagazineId))
 
-    // 🌟 매거진 주인이 '나'인지 판별 (실제 백엔드 DTO의 필드명에 맞게 수정해 주세요)
+    // 매거진 주인이 '나'인지 판별
     const isMyMagazine = magazineDetail?.user.id === user?.id
 
     const isAnyPending =
         postAddSectionMutation.isPending || postAddInSectionPageMutation.isPending || postMagazineMutation.isPending
 
-    if (!isLoggedIn || isHiddenPath) return null
+    if (!isLoggedIn || isHiddenPath || !isMyMagazine) return null
 
     const handleSend = (value: string) => {
         if (sectionMatch && isMyMagazine) {

--- a/Mine/src/hooks/useGetMagazineFeed.ts
+++ b/Mine/src/hooks/useGetMagazineFeed.ts
@@ -7,6 +7,7 @@ export default function useGetMagazineFeed() {
         queryKey: ['magazineFeed'],
         queryFn: ({ pageParam }: { pageParam: number | null }) => getMagazineFeed({ cursorId: pageParam }),
         initialPageParam: null,
-        getNextPageParam: (lastPage: ResponseFeed) => lastPage.hasNext ? lastPage.nextCursor : undefined,
+        getNextPageParam: (lastPage: ResponseFeed) => (lastPage.hasNext ? lastPage.nextCursor : undefined),
+        staleTime: 1000 * 60 * 5,
     })
 }

--- a/Mine/src/pages/magazine/MagazinePage.tsx
+++ b/Mine/src/pages/magazine/MagazinePage.tsx
@@ -12,6 +12,7 @@ import ScreenSettingsModal from '../../components/settings/ScreenSettingsModal'
 import ConfirmModal from '../../components/common/ConfirmModal'
 import useCreateMoodboard from '../../hooks/useCreateMoodboard'
 import Toast from '../../components/common/Toast'
+import useUserStore from '../../stores/user'
 
 const isValidUrl = (url?: string) => {
     if (!url) return false
@@ -25,6 +26,7 @@ const isValidUrl = (url?: string) => {
 
 export default function MagazinePage() {
     const { isOpen } = useSidebarStore()
+    const { user } = useUserStore()
     const { magazineId } = useParams()
     const { data, isPending } = useGetMagazineDetail(Number(magazineId))
     const navigate = useNavigate()
@@ -33,6 +35,8 @@ export default function MagazinePage() {
     const [isConfirmLoading, setIsConfirmLoading] = useState(false)
     const [showToast, setShowToast] = useState(false)
     const { mutateAsync: createMoodboard } = useCreateMoodboard()
+
+    const isMyMagazine = user?.id === data?.user.id
 
     useEffect(() => {
         if (!showToast) return
@@ -80,6 +84,7 @@ export default function MagazinePage() {
                                 mode="magazine"
                                 likeCount={data.likeCount} // data(섹션 상세정보)에서 가져온 하트수 전달
                                 isLiked={data.isLiked} // 내 좋아요 상태 전달
+                                isMyMagazine={isMyMagazine}
                             />
                         </div>
                     )}

--- a/Mine/src/pages/magazine/components/MagazineInfo.tsx
+++ b/Mine/src/pages/magazine/components/MagazineInfo.tsx
@@ -15,6 +15,7 @@ interface MagazineInfoProps {
     sectionId?: number
     likeCount?: number
     isLiked?: boolean
+    isMyMagazine: boolean
     mode: 'section' | 'magazine'
     onClick?: (magazineId: number) => void
 }
@@ -26,6 +27,7 @@ export default function MagazineInfo({
     magazineId,
     likeCount,
     isLiked,
+    isMyMagazine,
     mode,
     onClick,
 }: MagazineInfoProps) {
@@ -129,44 +131,46 @@ export default function MagazineInfo({
                     />
                 )}
 
-                <div className="relative flex items-center">
-                    <Hamburger
-                        className={`rotate-90 cursor-pointer ${mode === 'section' ? 'text-gray-300' : 'text-gray-100-op70'}`}
-                        onClick={toggleHamburger}
-                    />
+                {isMyMagazine && (
+                    <div className="relative flex items-center">
+                        <Hamburger
+                            className={`rotate-90 cursor-pointer ${mode === 'section' ? 'text-gray-300' : 'text-gray-100-op70'}`}
+                            onClick={toggleHamburger}
+                        />
 
-                    {isHamburgerOpen &&
-                        mode === 'section' &&
-                        magazinedata?.magazineId !== undefined &&
-                        sectionId !== undefined && (
-                            <SectionHamburgerModal
+                        {isHamburgerOpen &&
+                            mode === 'section' &&
+                            magazinedata?.magazineId !== undefined &&
+                            sectionId !== undefined && (
+                                <SectionHamburgerModal
+                                    handleClose={closeHamburger}
+                                    magazineId={magazinedata?.magazineId}
+                                    sectionId={sectionId}
+                                    heading={currentSectionHeading}
+                                    top={10}
+                                    left={10}
+                                    onEdit={() => {
+                                        closeHamburger()
+                                        beginSectionEdit()
+                                    }}
+                                />
+                            )}
+
+                        {isHamburgerOpen && mode === 'magazine' && magazinedata?.magazineId !== undefined && (
+                            <SidebarHamburgerModal
                                 handleClose={closeHamburger}
-                                magazineId={magazinedata?.magazineId}
-                                sectionId={sectionId}
-                                heading={currentSectionHeading}
+                                id={magazinedata.magazineId}
+                                title={magazinedata.title ?? ''}
                                 top={10}
                                 left={10}
                                 onEdit={() => {
                                     closeHamburger()
-                                    beginSectionEdit()
+                                    beginMagazineEdit()
                                 }}
                             />
                         )}
-
-                    {isHamburgerOpen && mode === 'magazine' && magazinedata?.magazineId !== undefined && (
-                        <SidebarHamburgerModal
-                            handleClose={closeHamburger}
-                            id={magazinedata.magazineId}
-                            title={magazinedata.title ?? ''}
-                            top={10}
-                            left={10}
-                            onEdit={() => {
-                                closeHamburger()
-                                beginMagazineEdit()
-                            }}
-                        />
-                    )}
-                </div>
+                    </div>
+                )}
             </div>
 
             <HeartCount

--- a/Mine/src/pages/magazine/components/ParagraphPart.tsx
+++ b/Mine/src/pages/magazine/components/ParagraphPart.tsx
@@ -14,6 +14,7 @@ interface ParagraphPartProps {
     smallTitle?: string
     content: string
     imageUrl?: string
+    isMyMagazine: boolean
 }
 
 export default function ParagraphPart({
@@ -24,6 +25,7 @@ export default function ParagraphPart({
     smallTitle,
     content,
     imageUrl,
+    isMyMagazine,
 }: ParagraphPartProps) {
     const magazinedata = useMagazine()
     const patchSectionMutation = usePatchSection()
@@ -110,27 +112,29 @@ export default function ParagraphPart({
                             className="bg-transparent outline-none font-medium36 font-notoserif text-gray-600 w-full"
                         />
                     )}
-                    <div className="relative flex items-center" dir="ltr">
-                        <Hamburger
-                            className="hover:text-black-icon text-black-icon cursor-pointer"
-                            onClick={handleHamburger}
-                        />
-                        {isHamburgerOpen && (
-                            <ParagraphHamburgerModal
-                                handleClose={closeHamburger}
-                                sectionId={sectionId}
-                                magazineId={magazinedata?.magazineId}
-                                paragraphId={paragrahId}
-                                subtitle={smallTitle ?? ''}
-                                top={10}
-                                left={10}
-                                onEdit={() => {
-                                    closeHamburger()
-                                    beginEdit()
-                                }}
+                    {isMyMagazine && (
+                        <div className="relative flex items-center" dir="ltr">
+                            <Hamburger
+                                className="hover:text-black-icon text-black-icon cursor-pointer"
+                                onClick={handleHamburger}
                             />
-                        )}
-                    </div>
+                            {isHamburgerOpen && (
+                                <ParagraphHamburgerModal
+                                    handleClose={closeHamburger}
+                                    sectionId={sectionId}
+                                    magazineId={magazinedata?.magazineId}
+                                    paragraphId={paragrahId}
+                                    subtitle={smallTitle ?? ''}
+                                    top={10}
+                                    left={10}
+                                    onEdit={() => {
+                                        closeHamburger()
+                                        beginEdit()
+                                    }}
+                                />
+                            )}
+                        </div>
+                    )}
                 </div>
                 <div className="w-full font-regular16 text-black-textMain break-all" dir="ltr">
                     <ReactMarkDown>{content}</ReactMarkDown>

--- a/Mine/src/pages/magazine/components/SectionContent.tsx
+++ b/Mine/src/pages/magazine/components/SectionContent.tsx
@@ -13,6 +13,7 @@ import ConfirmModal from '../../../components/common/ConfirmModal'
 import useCreateMoodboard from '../../../hooks/useCreateMoodboard'
 import Toast from '../../../components/common/Toast'
 import { useQueryClient } from '@tanstack/react-query'
+import useUserStore from '../../../stores/user'
 
 interface SectionContentProps {
     sectionId: number
@@ -21,17 +22,20 @@ interface SectionContentProps {
 
 export default function SectionContent({ sectionId, magazineId }: SectionContentProps) {
     const { isOpen } = useSidebarStore()
+    const { user } = useUserStore()
     const magazinedata = useMagazine()
     const navigate = useNavigate()
     const queryClient = useQueryClient()
     const { data, isLoading, isSuccess } = useGetSectionDetail(Number(magazineId), Number(sectionId))
-    const user = magazinedata?.user
+    const maguser = magazinedata?.user
     const content = data?.paragraphs
     const [isScreenSettingsOpen, setIsScreenSettingsOpen] = useState(false)
     const [isConfirmOpen, setIsConfirmOpen] = useState(false)
     const [isConfirmLoading, setIsConfirmLoading] = useState(false)
     const [showToast, setShowToast] = useState(false)
     const { mutateAsync: createMoodboard } = useCreateMoodboard()
+
+    const isMyMagazine = maguser?.id === user?.id
 
     useEffect(() => {
         if (!showToast) return
@@ -80,12 +84,13 @@ export default function SectionContent({ sectionId, magazineId }: SectionContent
                     <SectionIndexList sectionId={Number(sectionId)} />
                     <div className="flex flex-col w-245 items-center gap-14 mt-9 mb-22 z-10">
                         <MagazineInfo
-                            nickname={user?.nickname}
-                            profileImage={user?.profileImageUrl}
+                            nickname={maguser?.nickname}
+                            profileImage={maguser?.profileImageUrl}
                             sectionId={Number(sectionId)}
                             magazineId={Number(magazineId)}
                             likeCount={magazinedata?.likeCount} // data(섹션 상세정보)에서 가져온 하트수 전달
                             isLiked={magazinedata?.isLiked} // 내 좋아요 상태 전달
+                            isMyMagazine={isMyMagazine}
                             mode="section"
                             onClick={handleClick}
                         />
@@ -99,6 +104,7 @@ export default function SectionContent({ sectionId, magazineId }: SectionContent
                                 imageUrl={item?.imageUrl}
                                 sectionDir={index % 2 === 0 ? 'rtl' : 'ltr'}
                                 titleDir={index % 2 === 0 ? 'ltr' : 'rtl'}
+                                isMyMagazine={isMyMagazine}
                             />
                         ))}
                     </div>


### PR DESCRIPTION
## 🔗 관련 이슈
close #114

## ✨ 요약
남이 만든 매거진 페이지 화면이 변경되었습니다. 

## 📝 작업 내용
<img width="1910" height="948" alt="image" src="https://github.com/user-attachments/assets/9b6b8487-e911-4d14-b0fd-4fa66dd04c46" />
<img width="1915" height="945" alt="image" src="https://github.com/user-attachments/assets/ec3279bf-e0ec-41e5-96d3-579eb85ec31a" />

- [x] 남이 만든 매거진 페이지와 둘러보기, 저장한 매거진 페이지에서 LLM 입력칸을 삭제했습니다.
- [x] 남이 만든 매거진, 섹션 페이지에서 햄버거를 삭제했습니다.
- [x] 둘러보기 페이지(피드)에 staletime을 설정해 페이지 이동 간에서 불필요한 재호출을 막았습니다.

